### PR TITLE
Revise type definition for computed sort

### DIFF
--- a/computed.d.ts
+++ b/computed.d.ts
@@ -718,7 +718,7 @@ export function setDiff(
  */
 export function sort<T>(
   dependentKey: string,
-  sortDefinition: string[] | ((a: T, b: T) => number)
+  sortDefinition: string | ((a: T, b: T) => number)
 ): PropertyDecorator;
 /**
  * Decorator that wraps [Ember.computed.sum](http://emberjs.com/api/classes/Ember.computed.html#method_sum)


### PR DESCRIPTION
Based on the source https://github.com/emberjs/ember.js/blob/v2.15.3/packages/ember-runtime/lib/computed/reduce_computed_macros.js#L633

This should be a `string` not a `string[]` I think.  `string[]` is only the type of the dependent key.